### PR TITLE
Add delay to KeyDecoding.js loop

### DIFF
--- a/KeyDecoding.js
+++ b/KeyDecoding.js
@@ -531,4 +531,5 @@ while (true) {
     if (keyboard.getEscPress()) {
         chooseAndCreateKey();
     }
+    delay(10);
 }


### PR DESCRIPTION
I'm the person that was commenting to you on YouTube. I'm not very familiar with pull requests, but I think I did this right. All I did was add a 10 ms delay at the very end of the loop. I was looking things up and apparently when running in a loop without pause, there might not be time for system tasks to perform. I tested this and everything seems to work correctly.